### PR TITLE
fix: serve npm command path specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "serve": "http-serve -o ./build",
+    "serve": "http-serve ./build -o",
     "lint": "eslint --fix \"src/**/*.ts\" \"src/**/*.tsx\" && prettier --write \"src/**/*.ts\" \"src/**/*.tsx\"",
     "lint:check": "eslint \"src/**/*.ts\" \"src/**/*.tsx\" && prettier --check \"src/**/*.ts\" \"src/**/*.tsx\""
   },


### PR DESCRIPTION
When running the `http-serve -o ./build` command the path is not changed and it uses the default value (`./public`).

This seems to be a bug in `http-serve`. This also explains #98