### PR TITLE
fix: broken links /add prod env variables

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,6 @@
 REACT_APP_BEE_HOST=http://localhost:1633
 REACT_APP_BEE_DEBUG_HOST=http://localhost:1635
 REACT_APP_BEE_DOCS_HOST=https://docs.ethswarm.org/docs/
+REACT_APP_BEE_DISCORD_HOST=https://discord.gg/eKr9XPv7
+REACT_APP_ETHERSCAN_HOST=etherscan.io
 REACT_APP_BEE_GITHUB_REPO_URL=https://api.github.com/repos/ethersphere/bee


### PR DESCRIPTION
Adding the necessary environment variables to mirror [.env.development](https://github.com/ethersphere/bee-dashboard/blob/master/.env.development) to fix broken links to the discord server and etherscan