### PR TITLE
fix: add git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf 
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary


### PR DESCRIPTION
Addresses issue with windows builds. Some repo clones on windows automatically convert line endings of files to `CRLF` if their git settings are not configured for autocrlf [See link](https://docs.github.com/en/github/getting-started-with-github/getting-started-with-git/configuring-git-to-handle-line-endings#per-repository-settings) This causes issues with prettier on build ["endOfLine": "lf"](https://github.com/ethersphere/bee-dashboard/blob/master/.prettierrc#L10) and will result in the below error of `delete cr`. 

![image](https://user-images.githubusercontent.com/40722304/120016811-0e021200-bfb3-11eb-8dd2-e10c5b8baa80.png)


Alternatively, in the `.prettierrc` file **endOfLine** can be changed to "auto" but I think this is cleaner. [See "endOfLine"](https://github.com/ethersphere/bee-dashboard/blob/master/.prettierrc#L10)
