### PR TITLE
fix: don't display version alert when unable to retrieve version from bee node

### DIFF
--- a/src/components/AlertVersion.tsx
+++ b/src/components/AlertVersion.tsx
@@ -23,7 +23,7 @@ export default function VersionAlert(): ReactElement | null {
 
   const isExactlySupportedBeeVersion = SUPPORTED_BEE_VERSION_EXACT === userVersion
 
-  if (isLoading) return null
+  if (isLoading || !userVersion) return null
 
   return (
     <Collapse in={!isExactlySupportedBeeVersion && open}>


### PR DESCRIPTION
Before the fix:
![Screenshot 2021-06-03 at 9 51 08](https://user-images.githubusercontent.com/7974813/120610173-32e30300-c453-11eb-9124-8caa8fa9c56f.png) 

After the fix:
![Screenshot 2021-06-03 at 9 51 25](https://user-images.githubusercontent.com/7974813/120610204-38d8e400-c453-11eb-80e3-8b23388b6c46.png)
