### PR TITLE
feat: add retry to accounting

### DIFF
--- a/src/components/CashoutModal.tsx
+++ b/src/components/CashoutModal.tsx
@@ -1,15 +1,13 @@
-import { ReactElement, useState } from 'react'
+import { CircularProgress, Container } from '@material-ui/core'
 import Button from '@material-ui/core/Button'
 import Dialog from '@material-ui/core/Dialog'
 import DialogActions from '@material-ui/core/DialogActions'
 import DialogContent from '@material-ui/core/DialogContent'
 import DialogContentText from '@material-ui/core/DialogContentText'
 import DialogTitle from '@material-ui/core/DialogTitle'
-import { Container, CircularProgress } from '@material-ui/core'
 import { useSnackbar } from 'notistack'
-
+import { ReactElement, useState } from 'react'
 import { beeDebugApi } from '../services/bee'
-
 import EthereumAddress from './EthereumAddress'
 
 interface Props {
@@ -17,7 +15,7 @@ interface Props {
   uncashedAmount: string
 }
 
-export default function DepositModal({ peerId, uncashedAmount }: Props): ReactElement {
+export default function CheckoutModal({ peerId, uncashedAmount }: Props): ReactElement {
   const [open, setOpen] = useState<boolean>(false)
   const [loadingCashout, setLoadingCashout] = useState<boolean>(false)
   const { enqueueSnackbar } = useSnackbar()

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,7 +51,12 @@ export async function sleepMs(ms: number): Promise<void> {
   )
 }
 
-// TODO doc
+/**
+ * Maps the returned results of `Promise.allSettled` to an object
+ * with `fulfilled` and `rejected` arrays for easy access.
+ *
+ * The results still need to be unwrapped to get the fulfilled values or rejection reasons.
+ */
 export function mapPromiseSettlements<T>(promises: PromiseSettledResult<T>[]): PromiseSettlements<T> {
   const fulfilled = promises.filter(promise => promise.status === 'fulfilled') as PromiseFulfilledResult<T>[]
   const rejected = promises.filter(promise => promise.status === 'rejected') as PromiseRejectedResult[]
@@ -59,7 +64,13 @@ export function mapPromiseSettlements<T>(promises: PromiseSettledResult<T>[]): P
   return { fulfilled, rejected }
 }
 
-// TODO doc
+/**
+ * Maps the returned values of `Promise.allSettled` to an object
+ * with `fulfilled` and `rejected` arrays for easy access.
+ *
+ * For rejected promises, the value is the stringified `reason`,
+ * or `'Unknown error'` string when it is unavailable.
+ */
 export function unwrapPromiseSettlements<T>(
   promiseSettledResults: PromiseSettledResult<T>[],
 ): UnwrappedPromiseSettlements<T> {
@@ -70,6 +81,13 @@ export function unwrapPromiseSettlements<T>(
   return { fulfilled, rejected }
 }
 
+/**
+ * Wraps a `Promise<T>` or async function inside a new `Promise<T>`,
+ * which retries the original function up to `maxRetries` times,
+ * waiting `delayMs` milliseconds between failed attempts.
+ *
+ * If all attempts fail, then this `Promise<T>` also rejects.
+ */
 export function makeRetriablePromise<T>(fn: () => Promise<T>, maxRetries = 3, delayMs = 1000): Promise<T> {
   return new Promise(async (resolve, reject) => {
     for (let tries = 0; tries < maxRetries; tries++) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -79,7 +79,7 @@ export function makeRetriablePromise<T>(fn: () => Promise<T>, maxRetries = 3, de
 
         return
       } catch (error) {
-        if (tries < maxRetries) {
+        if (tries < maxRetries - 1) {
           await sleepMs(delayMs)
         } else {
           reject(error)


### PR DESCRIPTION
Reworked `Promise.all` to `Promise.allSettled`

Added utility fn to create retriable Promise

Before:

<img width="1187" alt="Screenshot 2021-08-11 at 14 00 58" src="https://user-images.githubusercontent.com/77121044/129025419-c143b59e-735f-42ff-bb9f-f5480add59b9.png">

After:

<img width="1192" alt="Screenshot 2021-08-11 at 14 02 44" src="https://user-images.githubusercontent.com/77121044/129025431-faf47d63-a977-41c0-bd94-43c6a593e2d2.png">


