### PR TITLE
fix: package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "check:types": "tsc --project tsconfig.lib.json"
   },
   "files": [
+    "lib",
     "build",
     "serve.js"
   ],


### PR DESCRIPTION
The types and the assets are not available in the npmjs package of the library at this moment.

This PR will fix that for the next build and release.

Thanks @AuHau for the tip!