### PR TITLE
style: make select and text input style consistent

### DIFF
--- a/src/components/SwarmSelect.tsx
+++ b/src/components/SwarmSelect.tsx
@@ -25,6 +25,11 @@ const useStyles = makeStyles((theme: Theme) =>
       '& fieldset': {
         border: 0,
       },
+      '& .MuiSelect-select': {
+        '&:focus': {
+          background: theme.palette.background.paper,
+        },
+      },
     },
     option: {
       height: '52px',
@@ -48,6 +53,7 @@ export function SwarmSelect({ defaultValue, formik, name, options, onChange, lab
           defaultValue={defaultValue || ''}
           className={classes.select}
           placeholder={label}
+          MenuProps={{ MenuListProps: { disablePadding: true }, PaperProps: { square: true } }}
         >
           {options.map((x, i) => (
             <MenuItem key={i} value={x.value} className={classes.option}>
@@ -71,6 +77,7 @@ export function SwarmSelect({ defaultValue, formik, name, options, onChange, lab
         defaultValue={defaultValue || ''}
         onChange={onChange}
         placeholder={label}
+        MenuProps={{ MenuListProps: { disablePadding: true }, PaperProps: { square: true } }}
       >
         {options.map((x, i) => (
           <MenuItem key={i} value={x.value} className={classes.option}>

--- a/src/components/SwarmTextInput.tsx
+++ b/src/components/SwarmTextInput.tsx
@@ -16,9 +16,17 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     field: {
       background: theme.palette.background.paper,
-      height: '52px',
       '& fieldset': {
         border: 0,
+      },
+      '& .Mui-focused': {
+        background: theme.palette.background.paper,
+      },
+      '& .MuiInputBase-root': {
+        background: theme.palette.background.paper,
+      },
+      '& .MuiFilledInput-root': {
+        borderRadius: 0,
       },
     },
   }),
@@ -36,9 +44,10 @@ export function SwarmTextInput({ name, label, password, optional, formik, onChan
         name={name}
         label={label}
         fullWidth
-        variant="outlined"
+        variant="filled"
         className={classes.field}
         defaultValue=""
+        InputProps={{ disableUnderline: true }}
       />
     )
   }
@@ -49,10 +58,11 @@ export function SwarmTextInput({ name, label, password, optional, formik, onChan
       required
       label={label}
       fullWidth
-      variant="outlined"
+      variant="filled"
       className={classes.field}
       defaultValue=""
       onChange={onChange}
+      InputProps={{ disableUnderline: true }}
     />
   )
 }


### PR DESCRIPTION
Removes border radius, padding, some gray backgrounds, and cleans up floating label being in awkward positions

![image](https://user-images.githubusercontent.com/77121044/150779870-a620a798-dfee-4233-a581-ff67a25b27f3.png)

![image](https://user-images.githubusercontent.com/77121044/150779900-f0bccd14-f447-4a36-9c0c-911f948eb2c5.png)
