### PR TITLE
feat: detect bee mode and enable/disable status checks accordingly

### DIFF
--- a/src/pages/info/index.tsx
+++ b/src/pages/info/index.tsx
@@ -17,6 +17,7 @@ export default function Status(): ReactElement {
     topology,
     nodeAddresses,
     chequebookAddress,
+    nodeInfo,
   } = useContext(BeeContext)
 
   if (!status.all) return <TroubleshootConnectionCard />
@@ -24,6 +25,7 @@ export default function Status(): ReactElement {
   return (
     <div>
       <ExpandableList label="Bee Node" defaultOpen>
+        <ExpandableListItem label="Mode" value={nodeInfo?.beeMode} />
         <ExpandableListItem
           label="Agent"
           value={

--- a/src/pages/status/SetupSteps/ChequebookDeployFund.tsx
+++ b/src/pages/status/SetupSteps/ChequebookDeployFund.tsx
@@ -10,7 +10,9 @@ import { Context } from '../../../providers/Bee'
 
 const ChequebookDeployFund = (): ReactElement | null => {
   const { status, isLoading, chequebookAddress } = useContext(Context)
-  const isOk = status.chequebook
+  const { isOk, isEnabled } = status.chequebook
+
+  if (!isEnabled) return null
 
   return (
     <ExpandableList

--- a/src/pages/status/SetupSteps/DebugConnectionCheck.tsx
+++ b/src/pages/status/SetupSteps/DebugConnectionCheck.tsx
@@ -12,7 +12,9 @@ import { Context as SettingsContext } from '../../../providers/Settings'
 export default function NodeConnectionCheck(): ReactElement | null {
   const { status, isLoading } = useContext(Context)
   const { setDebugApiUrl, apiDebugUrl } = useContext(SettingsContext)
-  const isOk = status.debugApiConnection
+  const { isOk, isEnabled } = status.debugApiConnection
+
+  if (!isEnabled) return null
 
   return (
     <ExpandableList

--- a/src/pages/status/SetupSteps/EthereumConnectionCheck.tsx
+++ b/src/pages/status/SetupSteps/EthereumConnectionCheck.tsx
@@ -7,7 +7,9 @@ import { Context } from '../../../providers/Bee'
 
 export default function EthereumConnectionCheck(): ReactElement | null {
   const { status, isLoading, nodeAddresses } = useContext(Context)
-  const isOk = status.blockchainConnection
+  const { isOk, isEnabled } = status.blockchainConnection
+
+  if (!isEnabled) return null
 
   return (
     <ExpandableList

--- a/src/pages/status/SetupSteps/NodeConnectionCheck.tsx
+++ b/src/pages/status/SetupSteps/NodeConnectionCheck.tsx
@@ -12,7 +12,9 @@ import { Context } from '../../../providers/Bee'
 export default function NodeConnectionCheck(): ReactElement | null {
   const { setApiUrl, apiUrl } = useContext(SettingsContext)
   const { status, isLoading } = useContext(Context)
-  const isOk = status.apiConnection
+  const { isEnabled, isOk } = status.apiConnection
+
+  if (!isEnabled) return null
 
   return (
     <ExpandableList

--- a/src/pages/status/SetupSteps/PeerConnection.tsx
+++ b/src/pages/status/SetupSteps/PeerConnection.tsx
@@ -7,7 +7,9 @@ import { Context } from '../../../providers/Bee'
 
 export default function PeerConnection(): ReactElement | null {
   const { status, isLoading, topology } = useContext(Context)
-  const isOk = status.topology
+  const { isEnabled, isOk } = status.topology
+
+  if (!isEnabled) return null
 
   return (
     <ExpandableList

--- a/src/pages/status/SetupSteps/VersionCheck.tsx
+++ b/src/pages/status/SetupSteps/VersionCheck.tsx
@@ -8,7 +8,9 @@ import { Context } from '../../../providers/Bee'
 
 export default function VersionCheck(): ReactElement | null {
   const { status, isLoading, latestUserVersion, latestPublishedVersion, latestBeeVersionUrl } = useContext(Context)
-  const isOk = status.version
+  const { isEnabled, isOk } = status.version
+
+  if (!isEnabled) return null
 
   return (
     <ExpandableList

--- a/src/providers/Bee.tsx
+++ b/src/providers/Bee.tsx
@@ -1,12 +1,13 @@
-import type {
+import {
   ChainState,
   ChequebookAddressResponse,
   Health,
   LastChequesResponse,
   NodeAddresses,
-  NodesInfo,
+  NodeInfo,
   Peer,
   Topology,
+  BeeModes,
 } from '@ethersphere/bee-js'
 import { createContext, ReactChild, ReactElement, useContext, useEffect, useState } from 'react'
 import semver from 'semver'
@@ -16,14 +17,19 @@ import { Token } from '../models/Token'
 import type { Balance, ChequebookBalance, Settlements } from '../types'
 import { Context as SettingsContext } from './Settings'
 
+interface StatusItem {
+  isEnabled: boolean
+  isOk: boolean
+}
+
 interface Status {
   all: boolean
-  version: boolean
-  blockchainConnection: boolean
-  debugApiConnection: boolean
-  apiConnection: boolean
-  topology: boolean
-  chequebook: boolean
+  version: StatusItem
+  blockchainConnection: StatusItem
+  debugApiConnection: StatusItem
+  apiConnection: StatusItem
+  topology: StatusItem
+  chequebook: StatusItem
 }
 
 interface ContextInterface {
@@ -37,7 +43,7 @@ interface ContextInterface {
   apiHealth: boolean
   debugApiHealth: Health | null
   nodeAddresses: NodeAddresses | null
-  nodeInfo: NodesInfo | null
+  nodeInfo: NodeInfo | null
   topology: Topology | null
   chequebookAddress: ChequebookAddressResponse | null
   peers: Peer[] | null
@@ -55,17 +61,15 @@ interface ContextInterface {
   refresh: () => Promise<void>
 }
 
-const startedInDevMode = window.location.search.includes('devMode=1')
-
 const initialValues: ContextInterface = {
   status: {
     all: false,
-    version: false,
-    blockchainConnection: false,
-    debugApiConnection: false,
-    apiConnection: false,
-    topology: false,
-    chequebook: false,
+    version: { isEnabled: false, isOk: false },
+    blockchainConnection: { isEnabled: false, isOk: false },
+    debugApiConnection: { isEnabled: false, isOk: false },
+    apiConnection: { isEnabled: false, isOk: false },
+    topology: { isEnabled: false, isOk: false },
+    chequebook: { isEnabled: false, isOk: false },
   },
   latestPublishedVersion: undefined,
   latestUserVersion: undefined,
@@ -104,34 +108,52 @@ interface Props {
 function getStatus(
   debugApiHealth: Health | null,
   nodeAddresses: NodeAddresses | null,
-  nodeInfo: NodesInfo | null,
+  nodeInfo: NodeInfo | null,
   apiHealth: boolean,
   topology: Topology | null,
   chequebookAddress: ChequebookAddressResponse | null,
   chequebookBalance: ChequebookBalance | null,
   error: Error | null,
 ): Status {
-  // FIXME: `devMode` is a temporary workaround to be able to develop with only one node
-  const devMode = startedInDevMode || Boolean(process.env.REACT_APP_DEV_MODE) || nodeInfo?.beeMode === 'dev'
   const status = {
-    version: Boolean(
-      debugApiHealth &&
-        semver.satisfies(debugApiHealth.version, engines.bee, {
-          includePrerelease: true,
-        }),
-    ),
-    blockchainConnection: Boolean(nodeAddresses?.ethereum),
-    debugApiConnection: Boolean(debugApiHealth?.status === 'ok'),
-    apiConnection: apiHealth,
-    topology: Boolean(topology?.connected && topology?.connected > 0) || devMode,
-    chequebook:
-      (Boolean(chequebookAddress?.chequebookAddress) &&
+    version: {
+      isEnabled: true,
+      isOk: Boolean(
+        debugApiHealth &&
+          semver.satisfies(debugApiHealth.version, engines.bee, {
+            includePrerelease: true,
+          }),
+      ),
+    },
+    blockchainConnection: {
+      isEnabled: true,
+      isOk: Boolean(nodeAddresses?.ethereum),
+    },
+    debugApiConnection: {
+      isEnabled: true,
+      isOk: Boolean(debugApiHealth?.status === 'ok'),
+    },
+    apiConnection: {
+      isEnabled: true,
+      isOk: apiHealth,
+    },
+    topology: {
+      isEnabled: Boolean(nodeInfo && [BeeModes.FULL, BeeModes.LIGHT, BeeModes.ULTRA_LIGHT].includes(nodeInfo.beeMode)),
+      isOk: Boolean(topology?.connected && topology?.connected > 0),
+    },
+    chequebook: {
+      isEnabled: Boolean(nodeInfo && [BeeModes.FULL, BeeModes.LIGHT].includes(nodeInfo.beeMode)),
+      isOk:
+        Boolean(chequebookAddress?.chequebookAddress) &&
         chequebookBalance !== null &&
-        chequebookBalance?.totalBalance.toBigNumber.isGreaterThan(0)) ||
-      devMode,
+        chequebookBalance?.totalBalance.toBigNumber.isGreaterThan(0),
+    },
   }
 
-  return { ...status, all: !error && Object.values(status).every(v => v) }
+  return {
+    ...status,
+    all: !error && Object.values(status).every(({ isEnabled, isOk }) => !isEnabled || (isEnabled && isOk)),
+  }
 }
 
 export function Provider({ children }: Props): ReactElement {
@@ -139,7 +161,7 @@ export function Provider({ children }: Props): ReactElement {
   const [apiHealth, setApiHealth] = useState<boolean>(false)
   const [debugApiHealth, setDebugApiHealth] = useState<Health | null>(null)
   const [nodeAddresses, setNodeAddresses] = useState<NodeAddresses | null>(null)
-  const [nodeInfo, setNodeInfo] = useState<NodesInfo | null>(null)
+  const [nodeInfo, setNodeInfo] = useState<NodeInfo | null>(null)
   const [topology, setNodeTopology] = useState<Topology | null>(null)
   const [chequebookAddress, setChequebookAddress] = useState<ChequebookAddressResponse | null>(null)
   const [peers, setPeers] = useState<Peer[] | null>(null)


### PR DESCRIPTION
fixes #309
resolves #307

I've decided to implement the disabling/enabling of the sidebar menu items in a different PR (e.g. chequebook should not be available in ultra-light mode)