### PR TITLE
feat: wait for postage stamp to be usable when bying it

### DIFF
--- a/src/pages/stamps/PostageStampCreation.tsx
+++ b/src/pages/stamps/PostageStampCreation.tsx
@@ -9,7 +9,13 @@ import { SwarmTextInput } from '../../components/SwarmTextInput'
 import { Context as BeeContext } from '../../providers/Bee'
 import { Context as SettingsContext } from '../../providers/Settings'
 import { Context as StampsContext } from '../../providers/Stamps'
-import { calculateStampPrice, convertAmountToSeconds, convertDepthToBytes, secondsToTimeString } from '../../utils'
+import {
+  calculateStampPrice,
+  convertAmountToSeconds,
+  convertDepthToBytes,
+  secondsToTimeString,
+  waitUntilStampUsable,
+} from '../../utils'
 import { getHumanReadableFileSize } from '../../utils/file'
 
 interface FormValues {
@@ -82,7 +88,8 @@ export function PostageStampCreation({ onFinished }: Props): ReactElement {
           const amount = BigInt(values.amount)
           const depth = Number.parseInt(values.depth)
           const options = values.label ? { label: values.label } : undefined
-          await beeDebugApi.createPostageBatch(amount.toString(), depth, options)
+          const batch = await beeDebugApi.createPostageBatch(amount.toString(), depth, options)
+          await waitUntilStampUsable(batch, beeDebugApi)
           actions.resetForm()
           await refresh()
           onFinished()


### PR DESCRIPTION
resolves #321 

This is a very minimal implementation of the functionality. I would like to point out that the UX here is pretty bad as it does not tell the user what is happening (e.g. the stamp was bought waiting for it to be usable) and if for whatever reason the stamp is not usable until the `DEFAULT_STAMP_USABLE_TIMEOUT = 120_000` is reached, it will fail with error message. My suggestion would be to merge this PR but have a design session with David how to improve the UX. On mainnet purchasing the stamp will take 30-90 seconds and then waiting for it to be usable also takes up to 90 seconds.