### PR TITLE
fix: remove restrictions on postage stamp label

### DIFF
--- a/src/pages/stamps/PostageStampCreation.tsx
+++ b/src/pages/stamps/PostageStampCreation.tsx
@@ -113,9 +113,6 @@ export function PostageStampCreation({ onFinished }: Props): ReactElement {
           else if (amount.isLessThanOrEqualTo(0)) errors.amount = 'Amount must be greater than 0'
         }
 
-        // Label
-        if (values.label && !/^[0-9a-z]*$/i.test(values.label)) errors.label = 'Label must be an alphanumeric string'
-
         return errors
       }}
     >


### PR DESCRIPTION
resolves #326

I've tested this and it works fine with any UTF-8 string on bee dev and bee-factory (even put it some evil czech characters :) )
<img width="1228" alt="Screenshot 2022-04-29 at 10 54 06" src="https://user-images.githubusercontent.com/7974813/165891560-325a68e4-154e-4420-a3d8-3fd5c446e334.png">

