### PR TITLE
fix: display account wallet partially while loading

### DIFF
--- a/src/pages/account/chequebook/AccountChequebook.tsx
+++ b/src/pages/account/chequebook/AccountChequebook.tsx
@@ -22,30 +22,37 @@ export function AccountChequebook(): ReactElement {
 
   if (status.all === CheckState.ERROR) return <TroubleshootConnectionCard />
 
+  const showChequebook = chequebookBalance?.totalBalance !== undefined
+
   return (
     <>
       <Header />
       <AccountNavigation active="CHEQUEBOOK" />
       <div>
-        <ExpandableList label="Chequebook" defaultOpen>
-          <ExpandableListItem label="Total Balance" value={`${chequebookBalance?.totalBalance.toFixedDecimal()} BZZ`} />
-          <ExpandableListItem
-            label="Available Uncommitted Balance"
-            value={`${chequebookBalance?.availableBalance.toFixedDecimal()} BZZ`}
-          />
-          <ExpandableListItem
-            label="Total Cheques Amount Sent"
-            value={`${settlements?.totalSent.toFixedDecimal()} BZZ`}
-          />
-          <ExpandableListItem
-            label="Total Cheques Amount Received"
-            value={`${settlements?.totalReceived.toFixedDecimal()} BZZ`}
-          />
-          <ExpandableListItemActions>
-            <WithdrawModal />
-            <DepositModal />
-          </ExpandableListItemActions>
-        </ExpandableList>
+        {showChequebook && (
+          <ExpandableList label="Chequebook" defaultOpen>
+            <ExpandableListItem
+              label="Total Balance"
+              value={`${chequebookBalance?.totalBalance.toFixedDecimal()} BZZ`}
+            />
+            <ExpandableListItem
+              label="Available Uncommitted Balance"
+              value={`${chequebookBalance?.availableBalance.toFixedDecimal()} BZZ`}
+            />
+            <ExpandableListItem
+              label="Total Cheques Amount Sent"
+              value={`${settlements?.totalSent.toFixedDecimal()} BZZ`}
+            />
+            <ExpandableListItem
+              label="Total Cheques Amount Received"
+              value={`${settlements?.totalReceived.toFixedDecimal()} BZZ`}
+            />
+            <ExpandableListItemActions>
+              <WithdrawModal />
+              <DepositModal />
+            </ExpandableListItemActions>
+          </ExpandableList>
+        )}
         <ExpandableList label="Blockchain" defaultOpen>
           <ExpandableListItemKey label="Ethereum address" value={nodeAddresses?.ethereum || ''} />
           <ExpandableListItemKey

--- a/src/pages/account/wallet/AccountWallet.tsx
+++ b/src/pages/account/wallet/AccountWallet.tsx
@@ -1,9 +1,9 @@
 import { Box, Grid, Typography } from '@material-ui/core'
 import { ReactElement, useContext } from 'react'
+import { useNavigate } from 'react-router'
 import Download from 'remixicon-react/DownloadLineIcon'
 import Gift from 'remixicon-react/GiftLineIcon'
 import Link from 'remixicon-react/LinkIcon'
-import { useNavigate } from 'react-router'
 import ExpandableListItem from '../../../components/ExpandableListItem'
 import ExpandableListItemActions from '../../../components/ExpandableListItemActions'
 import ExpandableListItemKey from '../../../components/ExpandableListItemKey'
@@ -18,10 +18,6 @@ export function AccountWallet(): ReactElement {
   const { balance, nodeAddresses } = useContext(Context)
 
   const navigate = useNavigate()
-
-  if (!balance || !nodeAddresses) {
-    return <Loading />
-  }
 
   function onCheckTransactions() {
     window.open(`https://blockscout.com/xdai/mainnet/address/${nodeAddresses?.ethereum}/transactions`, '_blank')
@@ -47,15 +43,23 @@ export function AccountWallet(): ReactElement {
           </SwarmButton>
         </Grid>
       </Box>
-      <Box mb={0.25}>
-        <ExpandableListItemKey label="Node wallet address" value={nodeAddresses.ethereum} expanded />
-      </Box>
-      <Box mb={0.25}>
-        <ExpandableListItem label="XDAI balance" value={`${balance.dai.toSignificantDigits(4)} XDAI`} />
-      </Box>
-      <Box mb={2}>
-        <ExpandableListItem label="BZZ balance" value={`${balance.bzz.toSignificantDigits(4)} BZZ`} />
-      </Box>
+      {balance && nodeAddresses ? (
+        <>
+          <Box mb={0.25}>
+            <ExpandableListItemKey label="Node wallet address" value={nodeAddresses.ethereum} expanded />
+          </Box>
+          <Box mb={0.25}>
+            <ExpandableListItem label="XDAI balance" value={`${balance.dai.toSignificantDigits(4)} XDAI`} />
+          </Box>
+          <Box mb={2}>
+            <ExpandableListItem label="BZZ balance" value={`${balance.bzz.toSignificantDigits(4)} BZZ`} />
+          </Box>
+        </>
+      ) : (
+        <Box mb={8}>
+          <Loading />
+        </Box>
+      )}
       <ExpandableListItemActions>
         <SwarmButton onClick={onCheckTransactions} iconType={Link}>
           Check transactions on Blockscout


### PR DESCRIPTION
Instead of fully hiding the Account page when loading the balances, this will only place the spinner in place of the balances, so the navigation and other information (even in ultra light mode) remains visible and functional.