### PR TITLE
fix: don't display buy new stamp button when already in process of buying one

### DIFF
--- a/src/pages/files/UploadActionBar.tsx
+++ b/src/pages/files/UploadActionBar.tsx
@@ -67,13 +67,15 @@ export function UploadActionBar({
             Back To Preview
           </SwarmButton>
         </ExpandableListItemActions>
-        <SwarmButton
-          disabled={stampMode === 'BUY' && !hasAnyStamps}
-          onClick={() => setStampMode(stampMode === 'BUY' ? 'SELECT' : 'BUY')}
-          iconType={stampMode === 'BUY' ? Layers : PlusSquare}
-        >
-          {stampMode === 'BUY' ? 'Use Existing Stamp' : 'Buy New Stamp'}
-        </SwarmButton>
+        {hasAnyStamps && (
+          <SwarmButton
+            disabled={stampMode === 'BUY' && !hasAnyStamps}
+            onClick={() => setStampMode(stampMode === 'BUY' ? 'SELECT' : 'BUY')}
+            iconType={stampMode === 'BUY' ? Layers : PlusSquare}
+          >
+            {stampMode === 'BUY' ? 'Use Existing Stamp' : 'Buy New Stamp'}
+          </SwarmButton>
+        )}
       </Grid>
     )
   }


### PR DESCRIPTION
![Screenshot 2022-06-21 at 12 07 02](https://user-images.githubusercontent.com/7974813/174774954-94b39ef6-7326-495e-a8c1-24af7fbae58a.png)
