### PR TITLE
feat: add upgrade guide link from medium

### DIFF
--- a/src/pages/rpc/index.tsx
+++ b/src/pages/rpc/index.tsx
@@ -39,7 +39,11 @@ export default function Index(): ReactElement {
         <Typography>
           To connect to and retrieve data from the blockchain, you&apos;ll need to connect to a publicly-provided node
           via the node&apos;s RPC endpoint. If you&apos;re not familiar with this, please read{' '}
-          <a href="https://medium.com/ethereum-swarm/upgrading-swarm-deskotp-app-beta-from-an-ultra-light-to-a-light-node-65d52cab7f2c" target="_blank" rel="noreferrer">
+          <a
+            href="https://medium.com/ethereum-swarm/upgrading-swarm-deskotp-app-beta-from-an-ultra-light-to-a-light-node-65d52cab7f2c"
+            target="_blank"
+            rel="noreferrer"
+          >
             this guide.
           </a>
           .

--- a/src/pages/rpc/index.tsx
+++ b/src/pages/rpc/index.tsx
@@ -38,9 +38,9 @@ export default function Index(): ReactElement {
       <Box mb={4}>
         <Typography>
           To connect to and retrieve data from the blockchain, you&apos;ll need to connect to a publicly-provided node
-          via the node&apos;s RPC endpoint. If you&apos;re not familiar with this, you may use{' '}
-          <a href="https://getblock.io/" target="_blank" rel="noreferrer">
-            https://getblock.io/
+          via the node&apos;s RPC endpoint. If you&apos;re not familiar with this, please read{' '}
+          <a href="https://medium.com/ethereum-swarm/upgrading-swarm-deskotp-app-beta-from-an-ultra-light-to-a-light-node-65d52cab7f2c" target="_blank" rel="noreferrer">
+            this guide.
           </a>
           .
         </Typography>


### PR DESCRIPTION
Added the medium blog post as a link instead of `getblock.io` after getting the feedback that people just copied it as is as an RPC endpoint.