### PR TITLE
ci: remove component build from release

### DIFF
--- a/.github/workflows/publish_npmjs.yaml
+++ b/.github/workflows/publish_npmjs.yaml
@@ -16,7 +16,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run compile:types
-      - run: npm run build:component
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This is follow up on #443 as it is included in `prepare` then it is not necessary do manually trigger the `npm run build:components` when releaseing.