### PR TITLE
feat: transfer everything out of the gift wallet

### DIFF
--- a/src/utils/bzz-abi.ts
+++ b/src/utils/bzz-abi.ts
@@ -1,4 +1,23 @@
-export const bzzContractInterface = [
+export const bzzABI = [
+  {
+    type: 'function',
+    stateMutability: 'view',
+    payable: false,
+    outputs: [
+      {
+        type: 'uint256',
+        name: '',
+      },
+    ],
+    name: 'balanceOf',
+    inputs: [
+      {
+        type: 'address',
+        name: '_owner',
+      },
+    ],
+    constant: true,
+  },
   {
     type: 'function',
     stateMutability: 'nonpayable',

--- a/src/utils/bzz-abi.ts
+++ b/src/utils/bzz-abi.ts
@@ -1,3 +1,4 @@
+export const BZZ_TOKEN_ADDRESS = '0xdBF3Ea6F5beE45c02255B2c26a16F300502F68da'
 export const bzzABI = [
   {
     type: 'function',

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -1,6 +1,6 @@
 import { debounce } from '@material-ui/core'
 import { Contract, providers, Wallet, BigNumber as BN } from 'ethers'
-import { bzzABI } from './bzz-abi'
+import { bzzABI, BZZ_TOKEN_ADDRESS } from './bzz-abi'
 
 async function eth_getBalance(address: string, provider: providers.JsonRpcProvider): Promise<string> {
   if (!address.startsWith('0x')) {
@@ -20,7 +20,7 @@ async function eth_getBlockByNumber(provider: providers.JsonRpcProvider): Promis
 async function eth_getBalanceERC20(
   address: string,
   provider: providers.JsonRpcProvider,
-  tokenAddress = '0xdbf3ea6f5bee45c02255b2c26a16f300502f68da',
+  tokenAddress = BZZ_TOKEN_ADDRESS,
 ): Promise<string> {
   if (!address.startsWith('0x')) {
     address = `0x${address}`
@@ -70,7 +70,7 @@ export async function sendBzzTransaction(
 ): Promise<TransferResponse> {
   const signer = await makeReadySigner(privateKey, jsonRpcProvider)
   const gasPrice = await signer.getGasPrice()
-  const bzz = new Contract('0xdBF3Ea6F5beE45c02255B2c26a16F300502F68da', bzzABI, signer)
+  const bzz = new Contract(BZZ_TOKEN_ADDRESS, bzzABI, signer)
   const transaction = await bzz.transfer(to, value, { gasPrice })
   const receipt = await transaction.wait(1)
 


### PR DESCRIPTION
So this is by no means perfect:

- It does not have any retry mechanism
- it does not correctly check on the UI if the balance is enough for both of the transfers.

But I think it is improvement over what is there right now.  I would like to do a complete refactor of this code later (we are creating providers all the time, I think we can better encapsulate things etc).