### PR TITLE
fix: don't link to latest release

### DIFF
--- a/src/pages/info/index.tsx
+++ b/src/pages/info/index.tsx
@@ -112,6 +112,7 @@ export default function Status(): ReactElement {
                 variant="outlined"
                 href={BEE_DESKTOP_LATEST_RELEASE_PAGE}
                 target="_blank"
+                disabled={newBeeDesktopVersion === ''}
                 style={{ height: '26px' }}
               >
                 {newBeeDesktopVersion === '' ? 'latest' : 'update'}
@@ -133,6 +134,7 @@ export default function Status(): ReactElement {
                 size="small"
                 variant="outlined"
                 href={latestBeeVersionUrl}
+                disabled={isLatestBeeVersion}
                 target="_blank"
                 style={{ height: '26px' }}
               >


### PR DESCRIPTION
This disables the `latest` badge at the Bee / Bee Desktop version when user runs latest in order not to confuse him.

<img width="174" alt="Screenshot 2022-07-06 at 11 15 58" src="https://user-images.githubusercontent.com/6072250/177516215-938f842e-c90b-4374-ac83-6f87178e8568.png">
