### PR TITLE
fix: set waitForUsable to false

### DIFF
--- a/src/pages/stamps/PostageStampCreation.tsx
+++ b/src/pages/stamps/PostageStampCreation.tsx
@@ -1,3 +1,4 @@
+import { PostageBatchOptions } from '@ethersphere/bee-js'
 import { Box, Grid, Typography } from '@material-ui/core'
 import BigNumber from 'bignumber.js'
 import { Form, Formik, FormikHelpers } from 'formik'
@@ -102,7 +103,7 @@ export function PostageStampCreation({ onFinished }: Props): ReactElement {
 
             const amount = BigInt(values.amount)
             const depth = Number.parseInt(values.depth)
-            const options = values.label ? { label: values.label } : undefined
+            const options: PostageBatchOptions = { waitForUsable: false, label: values.label || undefined }
             const batchId = await beeDebugApi.createPostageBatch(amount.toString(), depth, options)
             await waitUntilStampExists(batchId, beeDebugApi)
             actions.resetForm()


### PR DESCRIPTION
Since we have a custom waiting mechanism (only wait for "exists", then let user continue the flow, and wait for "usable" before uploading) I think this is needed.