### PR TITLE
fix: rpc endpoint setting ultra-light mode logic

### DIFF
--- a/src/hooks/apiHooks.tsx
+++ b/src/hooks/apiHooks.tsx
@@ -94,13 +94,10 @@ export interface BeeConfig {
   'swap-initial-deposit': bigint
   mainnet: boolean
   'full-node': boolean
-  'chain-enable': boolean
   'cors-allowed-origins': string
   'resolver-options': string
   'use-postage-snapshot': boolean
   'data-dir': string
-  transaction: string
-  'block-hash': string
   'swap-endpoint'?: string
 }
 

--- a/src/providers/Settings.tsx
+++ b/src/providers/Settings.tsx
@@ -2,7 +2,6 @@ import { Bee, BeeDebug } from '@ethersphere/bee-js'
 import { providers } from 'ethers'
 import { createContext, ReactNode, ReactElement, useEffect, useState } from 'react'
 import { useGetBeeConfig } from '../hooks/apiHooks'
-import { restartBeeNode, setJsonRpcInDesktop } from '../utils/desktop'
 import { DEFAULT_BEE_API_HOST, DEFAULT_BEE_DEBUG_API_HOST, DEFAULT_RPC_URL } from '../constants'
 
 const LocalStorageKeys = {
@@ -25,7 +24,7 @@ interface ContextInterface {
   ensResolver: string | null
   setApiUrl: (url: string) => void
   setDebugApiUrl: (url: string) => void
-  setAndPersistJsonRpcProvider: (url: string) => Promise<void>
+  setAndPersistJsonRpcProvider: (url: string) => void
   isLoading: boolean
   error: Error | null
 }
@@ -139,12 +138,7 @@ export function Provider({ children, ...propsSettings }: Props): ReactElement {
         cors: config?.['cors-allowed-origins'] ?? null,
         dataDir: config?.['data-dir'] ?? null,
         ensResolver: config?.['resolver-options'] ?? null,
-        setAndPersistJsonRpcProvider: setAndPersistJsonRpcProviderClosure(
-          isDesktop,
-          desktopUrl,
-          setRpcProviderUrl,
-          setRpcProvider,
-        ),
+        setAndPersistJsonRpcProvider: setAndPersistJsonRpcProviderClosure(setRpcProviderUrl, setRpcProvider),
         isLoading,
         error,
       }}
@@ -163,23 +157,12 @@ function makeHttpUrl(string: string): string {
 }
 
 function setAndPersistJsonRpcProviderClosure(
-  isDesktop: boolean,
-  desktopUrl: string,
   setProviderUrl: (url: string) => void,
   setProvider: (prov: providers.JsonRpcProvider) => void,
 ) {
-  return async (providerUrl: string) => {
-    try {
-      localStorage.setItem(LocalStorageKeys.providerUrl, providerUrl)
-      setProviderUrl(providerUrl)
-      setProvider(new providers.JsonRpcProvider(providerUrl))
-
-      if (isDesktop) {
-        await setJsonRpcInDesktop(desktopUrl, providerUrl)
-        await restartBeeNode(desktopUrl)
-      }
-    } catch (error) {
-      console.error(error) // eslint-disable-line
-    }
+  return (providerUrl: string) => {
+    localStorage.setItem(LocalStorageKeys.providerUrl, providerUrl)
+    setProviderUrl(providerUrl)
+    setProvider(new providers.JsonRpcProvider(providerUrl))
   }
 }

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -12,7 +12,6 @@ export async function getBzzPriceAsDai(desktopUrl: string): Promise<Token> {
 
 export async function upgradeToLightNode(desktopUrl: string, rpcProvider: string): Promise<void> {
   await updateDesktopConfiguration(desktopUrl, {
-    'chain-enable': true,
     'swap-enable': true,
     'swap-endpoint': rpcProvider,
   })


### PR DESCRIPTION
We can't set the RPC URL to the `swap-endpoint` Bee config value unless the Bee node is already in light mode as setting this config value, basically upgrades the node to light mode.