### PR TITLE
feat: wait for upload sync

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -5,7 +5,7 @@ import Typography from '@material-ui/core/Typography'
 import Box from '@material-ui/core/Box'
 
 interface Props {
-  linearProgressProps: LinearProgressProps
+  linearProgressProps?: LinearProgressProps
   value: number
 }
 

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,23 @@
+import React, { ReactElement } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import LinearProgress, { LinearProgressProps } from '@material-ui/core/LinearProgress'
+import Typography from '@material-ui/core/Typography'
+import Box from '@material-ui/core/Box'
+
+interface Props {
+  linearProgressProps: LinearProgressProps
+  value: number
+}
+
+export function LinearProgressWithLabel(props: Props): ReactElement {
+  return (
+    <Box display="flex" alignItems="center">
+      <Box width="100%" mr={1}>
+        <LinearProgress variant="determinate" {...props} />
+      </Box>
+      <Box minWidth={35}>
+        <Typography variant="body2" color="textSecondary">{`${Math.round(props.value)}%`}</Typography>
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from 'react'
-import { makeStyles } from '@material-ui/core/styles'
 import LinearProgress, { LinearProgressProps } from '@material-ui/core/LinearProgress'
 import Typography from '@material-ui/core/Typography'
 import Box from '@material-ui/core/Box'

--- a/src/pages/files/AssetSyncing.tsx
+++ b/src/pages/files/AssetSyncing.tsx
@@ -1,0 +1,72 @@
+import { Context as SettingsContext } from '../../providers/Settings'
+import { Box } from '@material-ui/core'
+import { ReactElement, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { DocumentationText } from '../../components/DocumentationText'
+import { LinearProgressWithLabel } from '../../components/ProgressBar'
+
+interface Props {
+  reference: string
+}
+
+export function AssetSyncing({ reference }: Props): ReactElement {
+  const { beeApi } = useContext(SettingsContext)
+
+  const syncTimer = useRef<NodeJS.Timer>()
+  const [syncProgress, setSyncProgress] = useState<number>(0)
+
+  const syncCheck = useCallback(async () => {
+    if (!beeApi) {
+      return
+    }
+
+    const tags = await beeApi.getAllTags()
+    const tag = tags.find(t => t.address === reference)
+
+    if (tag) {
+      const progress = ((tag.seen + tag.synced) / tag.split) * 100
+      setSyncProgress(progress)
+
+      // Check availablity from 70%
+      // There are occasions when it shows that the content is not synced but already available
+      if (progress > 70 && progress < 100) {
+        const isRetriavable = await beeApi.isReferenceRetrievable(reference)
+
+        if (isRetriavable) {
+          setSyncProgress(100)
+        }
+      }
+    }
+  }, [beeApi, reference])
+
+  useEffect(() => {
+    syncTimer.current = setInterval(syncCheck, 2000)
+
+    return () => {
+      if (syncTimer.current) {
+        clearInterval(syncTimer.current)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reference])
+
+  useEffect(() => {
+    if (syncProgress === 100 && syncTimer.current) {
+      clearInterval(syncTimer.current)
+    }
+  }, [syncProgress])
+
+  return (
+    <>
+      <Box mb={2}>
+        <DocumentationText>
+          Files are not immediately accessible on the Swarm network. Please wait until your upload is synced to the
+          network.{' '}
+          <a href="https://docs.ethswarm.org/docs/develop/access-the-swarm/syncing">Learn more about syncing</a>
+        </DocumentationText>
+      </Box>
+      <Box mb={4}>
+        <LinearProgressWithLabel value={syncProgress}></LinearProgressWithLabel>
+      </Box>
+    </>
+  )
+}

--- a/src/pages/files/AssetSyncing.tsx
+++ b/src/pages/files/AssetSyncing.tsx
@@ -1,6 +1,6 @@
 import { Context as SettingsContext } from '../../providers/Settings'
 import { Box } from '@material-ui/core'
-import { ReactElement, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { ReactElement, useContext, useEffect, useRef, useState } from 'react'
 import { DocumentationText } from '../../components/DocumentationText'
 import { LinearProgressWithLabel } from '../../components/ProgressBar'
 
@@ -12,9 +12,10 @@ export function AssetSyncing({ reference }: Props): ReactElement {
   const { beeApi } = useContext(SettingsContext)
 
   const syncTimer = useRef<NodeJS.Timer>()
+  const [isRetrieveChecking, setIsRetrieveChecking] = useState<boolean>(false)
   const [syncProgress, setSyncProgress] = useState<number>(0)
 
-  const syncCheck = useCallback(async () => {
+  const syncCheck = async () => {
     if (!beeApi) {
       return
     }
@@ -25,18 +26,8 @@ export function AssetSyncing({ reference }: Props): ReactElement {
     if (tag) {
       const progress = ((tag.seen + tag.synced) / tag.split) * 100
       setSyncProgress(progress)
-
-      // Check availablity from 70%
-      // There are occasions when it shows that the content is not synced but already available
-      if (progress > 70 && progress < 100) {
-        const isRetriavable = await beeApi.isReferenceRetrievable(reference)
-
-        if (isRetriavable) {
-          setSyncProgress(100)
-        }
-      }
     }
-  }, [beeApi, reference])
+  }
 
   useEffect(() => {
     syncTimer.current = setInterval(syncCheck, 2000)
@@ -55,13 +46,35 @@ export function AssetSyncing({ reference }: Props): ReactElement {
     }
   }, [syncProgress])
 
+  useEffect(() => {
+    /*   
+          There are instances when it seems that the content isn't synchronized, despite being already available.
+          To ensure it's not due to invalid synchronization data,
+          verify availability from at least 70% using one of the stewardship endpoints.
+          
+          TODO: is 70 a good number?
+    */
+    if (beeApi && !isRetrieveChecking && syncProgress > 10 && syncProgress < 100) {
+      // It's a long running task make sure only one run occurs at a time.
+      setIsRetrieveChecking(true)
+
+      beeApi.isReferenceRetrievable(reference).then(isRetriavable => {
+        if (isRetriavable) {
+          setSyncProgress(100)
+        }
+
+        setIsRetrieveChecking(false)
+      })
+    }
+  }, [syncProgress, isRetrieveChecking, beeApi, reference])
+
   return (
     <>
       <Box mb={2}>
         <DocumentationText>
           Files are not immediately accessible on the Swarm network. Please wait until your upload is synced to the
           network.{' '}
-          <a href="https://docs.ethswarm.org/docs/develop/access-the-swarm/syncing">Learn more about syncing</a>
+          <a href="https://docs.ethswarm.org/docs/develop/access-the-swarm/syncing">Learn more about syncing</a>.
         </DocumentationText>
       </Box>
       <Box mb={4}>

--- a/src/pages/files/Share.tsx
+++ b/src/pages/files/Share.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from '@material-ui/core'
 import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
 import { useSnackbar } from 'notistack'
-import { ReactElement, useContext, useEffect, useState } from 'react'
+import { ReactElement, useContext, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { HistoryHeader } from '../../components/HistoryHeader'
 import { Loading } from '../../components/Loading'
@@ -16,6 +16,7 @@ import { ManifestJs } from '../../utils/manifest'
 import { AssetPreview } from './AssetPreview'
 import { AssetSummary } from './AssetSummary'
 import { DownloadActionBar } from './DownloadActionBar'
+import { LinearProgressWithLabel } from '../../components/ProgressBar'
 
 export function Share(): ReactElement {
   const { apiUrl, beeApi } = useContext(SettingsContext)
@@ -34,6 +35,9 @@ export function Share(): ReactElement {
   const [notFound, setNotFound] = useState(false)
   const [preview, setPreview] = useState<string | undefined>(undefined)
   const [metadata, setMetadata] = useState<Metadata | undefined>()
+  const [syncProgress, setSyncProgress] = useState(0)
+
+  const syncTimer = useRef<NodeJS.Timer>()
 
   async function prepare() {
     if (!beeApi || !status.all) {
@@ -101,13 +105,51 @@ export function Share(): ReactElement {
     navigate(ROUTES.ACCOUNT_FEEDS_UPDATE.replace(':hash', reference))
   }
 
+  async function syncCheck() {
+    if (!beeApi) {
+      return
+    }
+
+    const tags = await beeApi.getAllTags()
+    const tag = tags.find(t => t.address === reference)
+
+    if (tag) {
+      const progress = ((tag.seen + tag.synced) / tag.split) * 100
+      setSyncProgress(progress)
+
+      // Check availablity from 70%
+      // There are occasions when it shows that the content is not synced but already available
+      if (progress > 70 && progress < 100) {
+        const isRetriavable = await beeApi.isReferenceRetrievable(reference)
+
+        if (isRetriavable) {
+          setSyncProgress(100)
+        }
+      }
+    }
+  }
+
   useEffect(() => {
     setLoading(true)
     prepare().finally(() => {
       setLoading(false)
     })
+
+    syncTimer.current = setInterval(syncCheck, 2000)
+
+    return () => {
+      if (syncTimer.current) {
+        clearInterval(syncTimer.current)
+      }
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reference])
+
+  useEffect(() => {
+    if (syncProgress === 100 && syncTimer.current) {
+      clearInterval(syncTimer.current)
+    }
+  }, [syncProgress])
 
   async function onDownload() {
     if (!beeApi) {
@@ -151,6 +193,14 @@ export function Share(): ReactElement {
       </Box>
       <Box mb={4}>
         <AssetSummary isWebsite={metadata?.isWebsite} reference={reference} />
+      </Box>
+      <Box mb={2}>
+        Files are not immediately accessible on the Swarm network. Please wait until your upload is synced to the
+        network.
+        <a href="https://docs.ethswarm.org/docs/develop/access-the-swarm/syncing">Learn more about syncing</a>
+      </Box>
+      <Box mb={4}>
+        <LinearProgressWithLabel value={syncProgress}></LinearProgressWithLabel>
       </Box>
       <DownloadActionBar
         onOpen={onOpen}

--- a/src/pages/files/Upload.tsx
+++ b/src/pages/files/Upload.tsx
@@ -207,7 +207,11 @@ export function Upload(): ReactElement {
       {step === 2 && stamp && (
         <>
           <StampPreview stamp={stamp} />
-          <Box mb={4}>Please do not close the application until your file is uploaded to your local node!</Box>
+          <Box mb={4}>
+            <DocumentationText>
+              Please do not close the application until your file is uploaded to your local node!
+            </DocumentationText>
+          </Box>
         </>
       )}
       <UploadActionBar

--- a/src/pages/files/Upload.tsx
+++ b/src/pages/files/Upload.tsx
@@ -204,7 +204,12 @@ export function Upload(): ReactElement {
           </Box>
         </>
       )}
-      {step === 2 && stamp && <StampPreview stamp={stamp} />}
+      {step === 2 && stamp && (
+        <>
+          <StampPreview stamp={stamp} />
+          <Box mb={4}>Please do not close the application until your file is uploaded to your local node!</Box>
+        </>
+      )}
       <UploadActionBar
         step={step}
         onCancel={reset}


### PR DESCRIPTION
Additional helper text added. Currently, if the application is closed during a local node upload, the upload fails. This functionality should ideally work seamlessly, even if the process happens in the background. I believe it's better to address this issue in a separate pull request.
<img width="732" alt="Screenshot 2023-12-18 at 12 42 52" src="https://github.com/ethersphere/bee-dashboard/assets/57348174/20dc9336-244c-4815-b10c-3f9182f39d17">

I monitor the syncing progress using the '/tags' endpoint. Once it reaches 70%, I begin utilizing one of the stewardship endpoints to enhance syncing resilience against potential issues with the syncing data.
<img width="732" alt="Screenshot 2023-12-18 at 12 43 05" src="https://github.com/ethersphere/bee-dashboard/assets/57348174/32d0443b-9c78-412b-9bdf-08623e8f4f15">

related issues:
https://github.com/ethersphere/bee-dashboard/issues/605
https://github.com/ethersphere/swarm-desktop/issues/385


@ethersphere/solar-punk
