### PR TITLE
ci: run the Check workflow on self-hosted runners

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, bee]
 
     strategy:
       matrix:


### PR DESCRIPTION
Switch this workflow to the org's self-hosted runners. Existing triggers unchanged.